### PR TITLE
Fixed typo on line #27

### DIFF
--- a/test/token/ERC20/CappedToken.test.js
+++ b/test/token/ERC20/CappedToken.test.js
@@ -24,7 +24,7 @@ contract('Capped', function (accounts) {
     assert.equal(result.logs[0].event, 'Mint');
   });
 
-  it('should fail to mint if the ammount exceeds the cap', async function () {
+  it('should fail to mint if the amount exceeds the cap', async function () {
     await token.mint(accounts[0], cap.sub(1));
     await expectThrow(token.mint(accounts[0], 100));
   });


### PR DESCRIPTION
Fixed "ammount" typo to "amount" on line 27 on test/token/ERC20/CappedToken.test.js.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #

# 🚀 Description


<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
